### PR TITLE
Force ransack gem version to fix undefined method 'polymorphic?'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,11 @@ gem 'faker', '~> 1.8.4'
 
 gem 'figaro', '>= 1.1.1'
 
+# Force gem version to fix:
+# undefined method `polymorphic?' for ActiveRecord::Reflection::PolymorphicReflection
+# See: https://github.com/activerecord-hackery/ransack/issues/1039
+gem 'ransack', '2.1.1'
+
 group :development, :test do
   gem 'byebug', platform: :mri
   gem 'decidim-dev', DECIDIM_VERSION

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -544,8 +544,6 @@ GEM
     pg_search (2.3.0)
       activerecord (>= 4.2)
       activesupport (>= 4.2)
-    polyamorous (2.3.0)
-      activerecord (>= 5.0)
     powerpack (0.1.2)
     premailer (1.11.1)
       addressable
@@ -595,12 +593,11 @@ GEM
       thor (>= 0.19.0, < 2.0)
     rainbow (3.0.0)
     rake (12.3.3)
-    ransack (2.3.0)
+    ransack (2.1.1)
       actionpack (>= 5.0)
       activerecord (>= 5.0)
       activesupport (>= 5.0)
       i18n
-      polyamorous (= 2.3.0)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
@@ -773,6 +770,7 @@ DEPENDENCIES
   letter_opener_web (~> 1.3.0)
   listen (~> 3.1.0)
   puma (~> 3.0)
+  ransack (= 2.1.1)
   spring
   spring-watcher-listen (~> 2.0.0)
   uglifier (>= 4.0.0)


### PR DESCRIPTION
Force ransack gem version to fix:
`undefined method 'polymorphic?' for ActiveRecord::Reflection::PolymorphicReflection`

See: https://github.com/activerecord-hackery/ransack/issues/1039