### PR TITLE
Fix new impersonation organization bug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,8 @@ ruby RUBY_VERSION
 DECIDIM_VERSION = { git: 'https://github.com/decidim/decidim.git', branch: '0.19-stable' }
 
 gem 'decidim', DECIDIM_VERSION
-gem 'decidim-file_authorization_handler', git: "https://github.com/MarsBased/decidim-file_authorization_handler.git"
+# IMPORTANT replace the organization from file_authorization_handler to MarsBased, remove the branch key and remove this comment
+gem 'decidim-file_authorization_handler', git: "https://github.com/CodiTramuntana/decidim-file_authorization_handler.git", branch: "fix/organization_error_on_manage_new_participant"
 # gem 'decidim-consultations', "~> #{DECIDIM_VERSION}"
 
 gem 'delayed_job_active_record'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GIT
-  remote: https://github.com/MarsBased/decidim-file_authorization_handler.git
-  revision: f01aaa7fcc9518228f7f079ca06c58aada8230c2
+  remote: https://github.com/CodiTramuntana/decidim-file_authorization_handler.git
+  revision: 5da7673bc057b44fd9eca7c1dfc7e36415e0fb2f
+  branch: fix/organization_error_on_manage_new_participant
   specs:
     decidim-file_authorization_handler (0.15.0)
       decidim (>= 0.15.0)


### PR DESCRIPTION
Tries to solve a crash occurring while managing a new impersonation.
Fix from the gem: MarsBased/decidim-file_authorization_handler#20
Related to: https://3.basecamp.com/4186608/buckets/12708820/todos/3173444074